### PR TITLE
[Hotfix] 修復Cache包含簡體中文無法儲存於非簡中編碼的伺服器上

### DIFF
--- a/mcdreforged_plugin_manager/storage/cache.py
+++ b/mcdreforged_plugin_manager/storage/cache.py
@@ -64,7 +64,7 @@ class Cache(PluginMetaInfoStorage):
     def save(self):
         if not os.path.isdir(os.path.dirname(self.CACHE_PATH)):
             os.makedirs(os.path.dirname(self.CACHE_PATH))
-        with open(self.CACHE_PATH, 'w+') as f:
+        with open(self.CACHE_PATH, 'w+', encoding='utf8') as f:
             json.dump(self.serialize(), f, indent=4, ensure_ascii=False)
 
     @classmethod
@@ -72,7 +72,7 @@ class Cache(PluginMetaInfoStorage):
         if not os.path.isfile(cls.CACHE_PATH):
             obj = cls()
         else:
-            with open(cls.CACHE_PATH, 'r') as f:
+            with open(cls.CACHE_PATH, 'r', encoding='utf8') as f:
                 data = json.load(f)
                 obj = cls.deserialize(data)
         return obj


### PR DESCRIPTION
- 修復Cache存讀檔時未使用utf8編碼，使得簡體中文無法儲存於非簡中編碼的伺服器上
- 提醒發布時記得修改config以進版